### PR TITLE
Umbraco Forms Support

### DIFF
--- a/Vertica.Umbraco.Headless.sln
+++ b/Vertica.Umbraco.Headless.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vertica.Umbraco.Headless.Co
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vertica.Umbraco.Headless.Swagger", "src\Vertica.Umbraco.Headless.Swagger\Vertica.Umbraco.Headless.Swagger.csproj", "{EF3802F4-9B27-4CE4-8DF9-B2174E52580B}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vertica.Umbraco.Headless.Forms", "src\Vertica.Umbraco.Headless.Forms\Vertica.Umbraco.Headless.Forms.csproj", "{AE49173B-980D-48B7-94CD-5F6BBE1F10F3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{EF3802F4-9B27-4CE4-8DF9-B2174E52580B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EF3802F4-9B27-4CE4-8DF9-B2174E52580B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EF3802F4-9B27-4CE4-8DF9-B2174E52580B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AE49173B-980D-48B7-94CD-5F6BBE1F10F3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AE49173B-980D-48B7-94CD-5F6BBE1F10F3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AE49173B-980D-48B7-94CD-5F6BBE1F10F3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AE49173B-980D-48B7-94CD-5F6BBE1F10F3}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Vertica.Umbraco.Headless.Forms/Extensions/UmbracoBuilderExtensions.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Extensions/UmbracoBuilderExtensions.cs
@@ -1,0 +1,13 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core.DependencyInjection;
+using Vertica.Umbraco.Headless.Forms.Services;
+
+namespace Vertica.Umbraco.Headless.Forms.Extensions;
+public static class UmbracoBuilderExtensions
+{
+    public static IUmbracoBuilder AddHeadlessForm(this IUmbracoBuilder builder)
+    {
+        builder.Services.AddSingleton<IHeadlessFormService, HeadlessFormService>();
+        return builder;
+    }
+}

--- a/src/Vertica.Umbraco.Headless.Forms/Extensions/UmbracoBuilderExtensions.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Extensions/UmbracoBuilderExtensions.cs
@@ -5,7 +5,7 @@ using Vertica.Umbraco.Headless.Forms.Services;
 namespace Vertica.Umbraco.Headless.Forms.Extensions;
 public static class UmbracoBuilderExtensions
 {
-    public static IUmbracoBuilder AddHeadlessForm(this IUmbracoBuilder builder)
+    public static IUmbracoBuilder AddHeadlessForms(this IUmbracoBuilder builder)
     {
         builder.Services.AddSingleton<IHeadlessFormService, HeadlessFormService>();
         return builder;

--- a/src/Vertica.Umbraco.Headless.Forms/Models/FormCondition.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Models/FormCondition.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Forms.Core.Enums;
+
+namespace Vertica.Umbraco.Headless.Forms.Models;
+public class FormCondition
+{
+    public FieldConditionActionType ActionType { get; set; }
+    public FieldConditionLogicType LogicType { get; set; }
+    public IEnumerable<FormConditionRule> Rules { get; set; } = Enumerable.Empty<FormConditionRule>();
+}

--- a/src/Vertica.Umbraco.Headless.Forms/Models/FormConditionRule.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Models/FormConditionRule.cs
@@ -1,0 +1,9 @@
+﻿using Umbraco.Forms.Core.Enums;
+
+namespace Vertica.Umbraco.Headless.Forms.Models;
+public class FormConditionRule
+{
+    public string Field { get; set; } = string.Empty;
+    public FieldConditionRuleOperator Operator { get; set; }
+    public string Value { get; set; } = string.Empty;
+}

--- a/src/Vertica.Umbraco.Headless.Forms/Models/FormConditionRuleOperator.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Models/FormConditionRuleOperator.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using Vertica.Umbraco.Headless.Forms.Rendering;
+
+namespace Vertica.Umbraco.Headless.Forms.Models;
+[JsonConverter(typeof(StringEnumConverter), typeof(UpperSnakeCaseNamingStrategy))]
+public enum FormConditionRuleOperator
+{
+    Is,
+    IsNot,
+    GreaterThen,
+    LessThen,
+    Contains,
+    StartsWith,
+    EndsWith
+}

--- a/src/Vertica.Umbraco.Headless.Forms/Models/FormField.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Models/FormField.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace Vertica.Umbraco.Headless.Forms.Models;
+public class FormField
+{
+    public string Caption { get; set; } = string.Empty;
+    public string? HelpText { get; set; } = string.Empty;
+    public string? Placeholder { get; set; } = string.Empty;
+    public string? CssClass { get; set; } = string.Empty;
+    public string Alias { get; set; } = string.Empty;
+    public bool Required { get; set; }
+    public string? RequiredErrorMessage { get; set; } = string.Empty;
+    public FormCondition? Condition { get; set; }
+    public IDictionary<string, string> Settings { get; set; } = new Dictionary<string, string>();
+    public object? PreValues { get; set; }
+    public string Type { get; set; } = string.Empty;
+
+}

--- a/src/Vertica.Umbraco.Headless.Forms/Models/FormFieldset.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Models/FormFieldset.cs
@@ -1,0 +1,11 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Vertica.Umbraco.Headless.Forms.Models;
+public class FormFieldset
+{
+    public string? Caption { get; set; } = string.Empty;
+    public FormCondition? Condition { get; set; }
+    public IEnumerable<FormFieldsetColumn> Columns { get; set; } = Enumerable.Empty<FormFieldsetColumn>();
+
+}

--- a/src/Vertica.Umbraco.Headless.Forms/Models/FormFieldsetColumn.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Models/FormFieldsetColumn.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Vertica.Umbraco.Headless.Forms.Models;
+public class FormFieldsetColumn
+{
+    public string? Caption { get; set; } = string.Empty;
+    public int Width { get; set; }
+    public IEnumerable<FormField> Fields { get; set; } = Enumerable.Empty<FormField>();
+}

--- a/src/Vertica.Umbraco.Headless.Forms/Models/FormPage.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Models/FormPage.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Vertica.Umbraco.Headless.Forms.Models;
+public class FormPage
+{
+    public string? Caption { get; set; } = string.Empty;
+    public IEnumerable<FormFieldset> Fieldsets { get; set; } = Enumerable.Empty<FormFieldset>();
+}

--- a/src/Vertica.Umbraco.Headless.Forms/Models/FormViewModel.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Models/FormViewModel.cs
@@ -1,0 +1,26 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Forms.Core.Enums;
+
+namespace Vertica.Umbraco.Headless.Forms.Models;
+public class FormViewModel
+{
+    [JsonProperty("_id")]
+    public Guid Id { get; set; }
+    public string Indicator { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? CssClass { get; set; } = string.Empty;
+    public string? NextLabel { get; set; } = string.Empty;
+    public string? PreviousLabel { get; set; } = string.Empty;
+    public string? SubmitLabel { get; set; } = string.Empty;
+    public bool DisableDefaultStylesheet { get; set; }
+    public FormFieldIndication FieldIndicationType { get; set; }
+    public bool HideFieldValidation { get; set; }
+    public string? MessageOnSubmit { get; set; } = string.Empty;
+    public bool ShowValidationSummary { get; set; }
+    public Guid? GotoPageOnSubmit { get; set; }
+    public IEnumerable<FormPage> Pages { get; set; } = Enumerable.Empty<FormPage>();
+}

--- a/src/Vertica.Umbraco.Headless.Forms/Rendering/FormsPropertyRenderer.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Rendering/FormsPropertyRenderer.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Forms.Core.Models;
+using Vertica.Umbraco.Headless.Core.Rendering;
+using Vertica.Umbraco.Headless.Forms.Services;
+
+namespace Vertica.Umbraco.Headless.Forms.Rendering;
+public class FormsPropertyRenderer : IPropertyRenderer
+{
+    private readonly IHeadlessFormService _headlessFormService;
+    public FormsPropertyRenderer(IHeadlessFormService headlessFormService)
+    {
+        _headlessFormService = headlessFormService;
+    }
+    public string PropertyEditorAlias => "UmbracoForms.FormPicker";
+    public Type TypeFor(IPublishedPropertyType propertyType) => typeof(Form);
+    public object ValueFor(object umbracoValue, IPublishedProperty property, IContentElementBuilder contentElementBuilder) => _headlessFormService.Get((Guid)umbracoValue);
+
+
+}

--- a/src/Vertica.Umbraco.Headless.Forms/Rendering/UpperSnakeCaseNamingStrategy.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Rendering/UpperSnakeCaseNamingStrategy.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json.Serialization;
+
+namespace Vertica.Umbraco.Headless.Forms.Rendering
+{
+    internal class UpperSnakeCaseNamingStrategy : SnakeCaseNamingStrategy
+    {
+        protected override string ResolvePropertyName(string name) =>
+            base.ResolvePropertyName(name).ToUpperInvariant();
+    }
+}

--- a/src/Vertica.Umbraco.Headless.Forms/Services/HeadlessFormService.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Services/HeadlessFormService.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Umbraco.Cms.Core;
+using Umbraco.Forms.Core.Models;
+using Umbraco.Forms.Core.Services;
+using Vertica.Umbraco.Headless.Forms.Models;
+
+namespace Vertica.Umbraco.Headless.Forms.Services
+{
+    public class HeadlessFormService : IHeadlessFormService
+    {
+        private readonly IFormService _formService;
+        private readonly IFieldTypeStorage _fieldTypeStorage;
+        private readonly IPublishedContentQueryAccessor _publishedContentQueryAccessor;
+        public HeadlessFormService(IFormService formService, IFieldTypeStorage fieldTypeStorage, IPublishedContentQueryAccessor publishedContentQueryAccessor)
+        {
+            _formService = formService;
+            _fieldTypeStorage = fieldTypeStorage;
+            _publishedContentQueryAccessor = publishedContentQueryAccessor;
+        }
+
+        public FormViewModel? Get(Guid id) => Convert(_formService.Get(id));
+        public FormViewModel? Get(string name) => Convert(_formService.Get(name));
+        public IEnumerable<FormViewModel?> Get(Guid[] ids) => _formService.Get(ids).Select(Convert);
+        public IEnumerable<FormViewModel?> Get() => _formService.Get().Select(Convert);
+
+        public FormViewModel? Convert(Form? form)
+        {
+            if (form == null) return null;
+            if (!(_publishedContentQueryAccessor.TryGetValue(out IPublishedContentQuery? publishedContentQuery))) throw new Exception($"Missing {nameof(publishedContentQuery)}");
+
+            return new FormViewModel()
+            {
+                Id = form.Id,
+                Indicator = form.Indicator,
+                CssClass = form.CssClass,
+                NextLabel = form.NextLabel,
+                DisableDefaultStylesheet = form.DisableDefaultStylesheet,
+                FieldIndicationType = form.FieldIndicationType,
+                GotoPageOnSubmit = publishedContentQuery.Content(form.GoToPageOnSubmit)?.Key,
+                HideFieldValidation = form.HideFieldValidation,
+                MessageOnSubmit = form.MessageOnSubmit,
+                Name = form.Name,
+                Pages = form.Pages.Select(FromPage),
+                PreviousLabel = form.PrevLabel,
+                ShowValidationSummary = form.ShowValidationSummary,
+                SubmitLabel = form.SubmitLabel,
+            };
+        }
+        private FormPage FromPage(Page page)
+        {
+            return new FormPage()
+            {
+                Caption = page.Caption,
+                Fieldsets = page.FieldSets.Select(FromFieldset)
+            };
+        }
+        private FormCondition? FromFieldCondition(FieldCondition? fieldCondition)
+        {
+            if (fieldCondition == null) return null;
+
+            return new FormCondition()
+            {
+                ActionType = fieldCondition.ActionType,
+                LogicType = fieldCondition.LogicType,
+                Rules = fieldCondition.Rules.Select(FromFieldConditionRule)
+            };
+        }
+        private FormConditionRule FromFieldConditionRule(FieldConditionRule fieldConditionRule)
+        {
+            return new FormConditionRule()
+            {
+                Field = fieldConditionRule.Field.ToString(),
+                Operator = fieldConditionRule.Operator,
+                Value = fieldConditionRule.Value
+            };
+        }
+        private FormFieldset FromFieldset(FieldSet fieldset)
+        {
+            return new FormFieldset()
+            {
+                Caption = fieldset.Caption,
+                Condition = FromFieldCondition(fieldset.Condition),
+                Columns = fieldset.Containers.Select(FromFieldsetContainer),
+            };
+        }
+        private FormFieldsetColumn FromFieldsetContainer(FieldsetContainer container)
+        {
+            return new FormFieldsetColumn()
+            {
+                Caption = container.Caption,
+                Width = container.Width,
+                Fields = container.Fields.Select(fromField),
+            };
+        }
+        private FormField fromField(Field field)
+        {
+            return new FormField()
+            {
+                Caption = field.Caption,
+                Alias = field.Alias,
+                Condition = FromFieldCondition(field.Condition),
+                CssClass = field.CssClass,
+                HelpText = field.ToolTip,
+                Placeholder = field.Placeholder,
+                PreValues = field.PreValues,
+                Required = field.Mandatory,
+                RequiredErrorMessage = field.RequiredErrorMessage,
+                Settings = field.Settings,
+                Type = GetFieldTypeName(field)
+        };
+        }
+
+        private string GetFieldTypeName(Field field) 
+            => _fieldTypeStorage
+                .GetFieldTypeByField(field)
+                .GetType()
+                .Name
+                .ToLower();
+    }
+}

--- a/src/Vertica.Umbraco.Headless.Forms/Services/IHeadlessFormService.cs
+++ b/src/Vertica.Umbraco.Headless.Forms/Services/IHeadlessFormService.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using Umbraco.Forms.Core.Models;
+using Vertica.Umbraco.Headless.Forms.Models;
+
+namespace Vertica.Umbraco.Headless.Forms.Services
+{
+    public interface IHeadlessFormService
+    {
+        public FormViewModel? Get(Guid id);
+        public FormViewModel? Get(string name);
+        public IEnumerable<FormViewModel?> Get(Guid[] ids);
+        public IEnumerable<FormViewModel?> Get();
+        public FormViewModel? Convert(Form form);
+    }
+}

--- a/src/Vertica.Umbraco.Headless.Forms/Vertica.Umbraco.Headless.Forms.csproj
+++ b/src/Vertica.Umbraco.Headless.Forms/Vertica.Umbraco.Headless.Forms.csproj
@@ -10,7 +10,8 @@
         <PackageIcon>Vertica.png</PackageIcon>
         <Copyright>Vertica A/S</Copyright>
         <Nullable>enable</Nullable>
-        <Version>0.1.0</Version>
+        <!-- Version is set during release build -->
+        <!-- <Version></Version> -->
         <Description>Umbraco Forms support for Vertica.Umbraco.Headless.Core</Description>
         <PackageProjectUrl>https://github.com/vertica-as/vertica.umbraco.headless</PackageProjectUrl>
     </PropertyGroup>

--- a/src/Vertica.Umbraco.Headless.Forms/Vertica.Umbraco.Headless.Forms.csproj
+++ b/src/Vertica.Umbraco.Headless.Forms/Vertica.Umbraco.Headless.Forms.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <Authors>Lars Nikander Frandsen</Authors>
+        <Company>Vertica A/S</Company>
+        <Product>Vertica Umbraco Headless Framework</Product>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageIcon>Vertica.png</PackageIcon>
+        <Copyright>Vertica A/S</Copyright>
+        <Nullable>enable</Nullable>
+        <Version>0.1.0</Version>
+        <Description>Umbraco Forms support for Vertica.Umbraco.Headless.Core</Description>
+        <PackageProjectUrl>https://github.com/vertica-as/vertica.umbraco.headless</PackageProjectUrl>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <None Include="..\..\build\Vertica.png">
+            <Pack>True</Pack>
+            <PackagePath>\</PackagePath>
+        </None>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Umbraco.Cms.Core" Version="[9.0.1,11.0.0)" />
+        <PackageReference Include="Umbraco.Forms.core" Version="[9.0.1,11.0.0)" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Vertica.Umbraco.Headless.Core\Vertica.Umbraco.Headless.Core.csproj" />
+    </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Added property renderer for umbraco forms that mimics the output in Heartcore.

To use: 

```
services.AddUmbraco(_env, _config)
                .AddBackOffice()
                .AddWebsite()
                .AddComposers()
                .AddHeadless()
                .AddHeadlessForms()
                .Build();
```