### PR TITLE
Added block grid property renderer as separate project to target Umbraco 10.3+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
         dotnet-version: | 
           5.0.x
           6.0.x
+          7.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         dotnet-version: | 
           5.0.x
           6.0.x
+          7.0.x
     - name: Restore dependencies
       run: dotnet restore
     - name: Build
@@ -70,6 +71,17 @@ jobs:
         asset_path: ./nupkgs/Vertica.Umbraco.Headless.Swagger.${{ env.releaseversion }}.nupkg
         asset_name: Vertica.Umbraco.Headless.Swagger.${{ env.releaseversion }}.nupkg
         asset_content_type: application/zip        
+    # Add the block grid package as an asset
+    - name: Upload Release Asset Block Grid
+      id: upload-release-asset-block-grid
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./nupkgs/Vertica.Umbraco.Headless.BlockGrid.${{ env.releaseversion }}.nupkg
+        asset_name: Vertica.Umbraco.Headless.BlockGrid.${{ env.releaseversion }}.nupkg
+        asset_content_type: application/zip
     - name: Push to NuGet - Core
       run: dotnet nuget push ./nupkgs/Vertica.Umbraco.Headless.Core.${{ env.releaseversion }}.nupkg -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
       env: 
@@ -77,4 +89,8 @@ jobs:
     - name: Push to NuGet - Swagger
       run: dotnet nuget push ./nupkgs/Vertica.Umbraco.Headless.Swagger.${{ env.releaseversion }}.nupkg -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
       env: 
+        NUGET_AUTH_TOKEN: ${{ secrets.NUGET_TOKEN }}
+    - name: Push to NuGet - Block Grid
+      run: dotnet nuget push ./nupkgs/Vertica.Umbraco.Headless.BlockGrid.${{ env.releaseversion }}.nupkg -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json
+      env:
         NUGET_AUTH_TOKEN: ${{ secrets.NUGET_TOKEN }}

--- a/Vertica.Umbraco.Headless.sln
+++ b/Vertica.Umbraco.Headless.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vertica.Umbraco.Headless.Co
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Vertica.Umbraco.Headless.Swagger", "src\Vertica.Umbraco.Headless.Swagger\Vertica.Umbraco.Headless.Swagger.csproj", "{EF3802F4-9B27-4CE4-8DF9-B2174E52580B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Vertica.Umbraco.Headless.BlockGrid", "src\Vertica.Umbraco.Headless.BlockGrid\Vertica.Umbraco.Headless.BlockGrid.csproj", "{0A5B3EF5-7DD2-489A-BFEA-CA4DCAB035FC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{EF3802F4-9B27-4CE4-8DF9-B2174E52580B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EF3802F4-9B27-4CE4-8DF9-B2174E52580B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EF3802F4-9B27-4CE4-8DF9-B2174E52580B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0A5B3EF5-7DD2-489A-BFEA-CA4DCAB035FC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A5B3EF5-7DD2-489A-BFEA-CA4DCAB035FC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A5B3EF5-7DD2-489A-BFEA-CA4DCAB035FC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A5B3EF5-7DD2-489A-BFEA-CA4DCAB035FC}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Vertica.Umbraco.Headless.BlockGrid/Models/BlockGrid.cs
+++ b/src/Vertica.Umbraco.Headless.BlockGrid/Models/BlockGrid.cs
@@ -1,0 +1,6 @@
+namespace Vertica.Umbraco.Headless.BlockGrid.Models;
+public class BlockGrid
+{
+    public int? GridColumns { get; set; }
+    public IEnumerable<BlockGridElement> Blocks { get; set; } = Array.Empty<BlockGridElement>();
+}

--- a/src/Vertica.Umbraco.Headless.BlockGrid/Models/BlockGridAreaElement.cs
+++ b/src/Vertica.Umbraco.Headless.BlockGrid/Models/BlockGridAreaElement.cs
@@ -1,0 +1,13 @@
+namespace Vertica.Umbraco.Headless.BlockGrid.Models;
+public class BlockGridAreaElement
+{
+#if NET7_0_OR_GREATER
+    public required string Alias { get; set; }
+#else
+    public string Alias { get; set; } = string.Empty;
+#endif
+
+    public int RowSpan { get; set; }
+    public int ColumnSpan { get; set; }
+    public IEnumerable<BlockGridElement> Blocks { get; set; } = Array.Empty<BlockGridElement>();
+}

--- a/src/Vertica.Umbraco.Headless.BlockGrid/Models/BlockGridElement.cs
+++ b/src/Vertica.Umbraco.Headless.BlockGrid/Models/BlockGridElement.cs
@@ -1,0 +1,14 @@
+using Vertica.Umbraco.Headless.Core.Models;
+
+namespace Vertica.Umbraco.Headless.BlockGrid.Models
+{
+    public class BlockGridElement : ContentElementWithSettings
+    {
+        public int RowSpan { get; set; }
+        public int ColumnSpan { get; set; }
+        public bool ForceLeft { get; set; }
+        public bool ForceRight { get; set; }
+        public int? AreaGridColumns { get; set; }
+        public IEnumerable<BlockGridAreaElement>? Areas { get; set; }
+    }
+}

--- a/src/Vertica.Umbraco.Headless.BlockGrid/Rendering/PropertyRenderers/BlockGridPropertyRenderer.cs
+++ b/src/Vertica.Umbraco.Headless.BlockGrid/Rendering/PropertyRenderers/BlockGridPropertyRenderer.cs
@@ -1,0 +1,49 @@
+using Umbraco.Cms.Core;
+using Umbraco.Cms.Core.Models.Blocks;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Vertica.Umbraco.Headless.Core.Models;
+using Vertica.Umbraco.Headless.Core.Rendering;
+using Vertica.Umbraco.Headless.BlockGrid.Models;
+
+namespace Vertica.Umbraco.Headless.BlockGrid.Rendering.PropertyRenderers;
+public class BlockGridPropertyRenderer : IPropertyRenderer
+{
+    public string PropertyEditorAlias => Constants.PropertyEditors.Aliases.BlockGrid;
+
+    public Type TypeFor(IPublishedPropertyType propertyType) => typeof(Models.BlockGrid);
+
+    public virtual object? ValueFor(object umbracoValue, IPublishedProperty property, IContentElementBuilder contentElementBuilder)
+        => umbracoValue is BlockGridModel grid
+            ? new Models.BlockGrid
+            {
+                GridColumns = grid.GridColumns,
+                Blocks = grid.Select(i => BlockGridElementFor(contentElementBuilder, i)).ToArray(),
+            }
+            : null;
+
+    private static BlockGridElement BlockGridElementFor(IContentElementBuilder builder, BlockGridItem item)
+    {
+        var contentElementWithSettings = builder.ContentElementFor<BlockGridElement>(item.Content);
+        contentElementWithSettings.Settings = builder.ContentElementFor<ContentElement>(item.Settings);
+        contentElementWithSettings.RowSpan = item.RowSpan;
+        contentElementWithSettings.ColumnSpan = item.ColumnSpan;
+        contentElementWithSettings.ForceLeft = item.ForceLeft;
+        contentElementWithSettings.ForceRight = item.ForceRight;
+        contentElementWithSettings.AreaGridColumns = item.AreaGridColumns;
+        contentElementWithSettings.Areas = item.Areas?.Any() == true
+            ? item.Areas?.Select(area => BlockGridAreaElementFor(builder, area))
+            : null;
+        return contentElementWithSettings;
+    }
+
+    private static BlockGridAreaElement BlockGridAreaElementFor(IContentElementBuilder builder, BlockGridArea area)
+    {
+        return new BlockGridAreaElement
+        {
+            Alias = area.Alias,
+            ColumnSpan = area.ColumnSpan,
+            RowSpan = area.RowSpan,
+            Blocks = area.Select(block => BlockGridElementFor(builder, block)),
+        };
+    }
+}

--- a/src/Vertica.Umbraco.Headless.BlockGrid/Vertica.Umbraco.Headless.BlockGrid.csproj
+++ b/src/Vertica.Umbraco.Headless.BlockGrid/Vertica.Umbraco.Headless.BlockGrid.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\build\Vertica.png">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Umbraco.Cms.Core" Version="[10.3.0,12.0.0)" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Vertica.Umbraco.Headless.Core\Vertica.Umbraco.Headless.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Vertica.Umbraco.Headless.Core/Vertica.Umbraco.Headless.Core.csproj
+++ b/src/Vertica.Umbraco.Headless.Core/Vertica.Umbraco.Headless.Core.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;net7.0</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Authors>Kenn Jacobsen</Authors>
     <Company>Vertica A/S</Company>
@@ -14,18 +13,15 @@
     <Description>Framework for creating headless experiences with Umbraco CMS</Description>
     <PackageProjectUrl>https://github.com/vertica-as/vertica.umbraco.headless</PackageProjectUrl>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Umbraco.Cms.Core" Version="[9.0.1,11.0.0)" />
-    <PackageReference Include="Umbraco.Cms.Web.Common" Version="[9.0.1,11.0.0)" />
-    <PackageReference Include="Umbraco.Cms.Web.Website" Version="[9.0.1,11.0.0)" />
+    <PackageReference Include="Umbraco.Cms.Core" Version="[9.0.1,12.0.0)" />
+    <PackageReference Include="Umbraco.Cms.Web.Common" Version="[9.0.1,12.0.0)" />
+    <PackageReference Include="Umbraco.Cms.Web.Website" Version="[9.0.1,12.0.0)" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="..\..\build\Vertica.png">
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
-
 </Project>

--- a/src/Vertica.Umbraco.Headless.Swagger/Vertica.Umbraco.Headless.Swagger.csproj
+++ b/src/Vertica.Umbraco.Headless.Swagger/Vertica.Umbraco.Headless.Swagger.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <Authors>Kenn Jacobsen</Authors>
     <Company>Vertica A/S</Company>
@@ -14,21 +13,17 @@
     <Description>Swagger support for Vertica.Umbraco.Headless.Core</Description>
     <PackageProjectUrl>https://github.com/vertica-as/vertica.umbraco.headless</PackageProjectUrl>
   </PropertyGroup>
-
   <ItemGroup>
     <None Include="..\..\build\Vertica.png">
       <Pack>True</Pack>
       <PackagePath>\</PackagePath>
     </None>
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.2.3" />
-    <PackageReference Include="Umbraco.Cms.Core" Version="[9.0.1,11.0.0)" />
+    <PackageReference Include="Umbraco.Cms.Core" Version="[9.0.1,12.0.0)" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Vertica.Umbraco.Headless.Core\Vertica.Umbraco.Headless.Core.csproj" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Unsolved issues:
* Currently the property renderer override works by finding renderers not originating from the core assembly. Since this renderer comes from a separate assembly it will not be filtered away.
* Documentation for the new property editor?

Questions:
* Do we need to reserve the NuGet package name before pushing through CI?
* It seems like ForceLeft/ForceRight might be removed in the (near) future: https://github.com/umbraco/Umbraco-CMS/pull/13391
